### PR TITLE
Removed CONCURRENTLY from the refresh materialized view command

### DIFF
--- a/src/peoplemeasurement/management/commands/refresh_materialized_view.py
+++ b/src/peoplemeasurement/management/commands/refresh_materialized_view.py
@@ -17,5 +17,5 @@ class Command(BaseCommand):
 
         log.info(f"Start refreshing the {view_name}")
         with connection.cursor() as cursor:
-            cursor.execute(f"REFRESH MATERIALIZED VIEW CONCURRENTLY {view_name};")
+            cursor.execute(f"REFRESH MATERIALIZED VIEW {view_name};")
         log.info(f"Done refreshing the {view_name}")


### PR DESCRIPTION
The reason is that it creates errors saying it cannot refresh materialized view X concurrently
HINT: Create a unique index with no WHERE clause on one or more columns of the materialized view.

This first needs to be solved before this concurrent refreshing can take place.